### PR TITLE
Update for compatability with Laravel 5.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     },
     "require": {
         "optimus/api-consumer": "0.2.*",
-        "laravel/framework": "~5.1"
+        "laravel/framework": "~5.2"
     },
     "require-dev": {
         "mockery/mockery": "0.9.*",

--- a/src/Provider/LaravelServiceProvider.php
+++ b/src/Provider/LaravelServiceProvider.php
@@ -24,7 +24,7 @@ class LaravelServiceProvider extends BaseProvider {
 
     public function bindInstance()
     {
-        $this->app->bindShared('batchrequest', function(){
+        $this->app->singleton('batchrequest', function(){
             $config = $this->app['config']->get('batchrequest');
             $database = $this->app['db'];
             $request = $this->app['request'];

--- a/tests/Provider/LaravelServiceProviderTest.php
+++ b/tests/Provider/LaravelServiceProviderTest.php
@@ -27,7 +27,7 @@ class LaravelServiceProviderTest extends Orchestra\Testbench\TestCase {
 
     public function testBindInstanceCallsContainer()
     {
-        $this->appMock->shouldReceive('bindShared')->with(
+        $this->appMock->shouldReceive('singleton')->with(
             'batchrequest',
             m::type('Closure')
         );


### PR DESCRIPTION
See the deprecations part of the [upgrade guide](https://laravel.com/docs/5.2/upgrade#upgrade-5.1.11). The `bindShared()` has been renamed to `singleton()` in Laravel 5.2
